### PR TITLE
Fix skill name inconsistency for Auto-Lick passive skill

### DIFF
--- a/data/skill_to_hex.txt
+++ b/data/skill_to_hex.txt
@@ -363,7 +363,7 @@ FF 00 | Blinding Curse
 6C 01 | Phys ATK Up (Passive)
 6D 01 | Phys DEF Up (Passive)
 6E 01 | Deadly Resolve (Passive)
-6F 01 | Auto Lick (Passive)
+6F 01 | Auto-Lick (Passive)
 70 01 | Loyalty Mastery (Passive)
 71 01 | Claw Mastery (Passive)
 72 01 | Preemptive Roar (Passive)


### PR DESCRIPTION
Fixed an inconsistency between skill_to_hex.txt and player_skills.txt where "Auto Lick" was written differently from "Auto-Lick", causing the grimoire parser to fail when encountering an Auto-Lick grimoire, as well as the skill being unavailable during grimoire editing.